### PR TITLE
Possible cause of device jamming

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ gem install farmbot-serial, '0.0.5'
 ```
 
 ```ruby
+require 'eventmachine'
 require 'farmbot-serial'
 
 bot = FB::Arduino.new # Defaults to '/dev/ttyACM0', can be configured.

--- a/chat.rb
+++ b/chat.rb
@@ -1,0 +1,7 @@
+require_relative 'lib/default_serial_port'
+require 'pry'
+
+serial = FB::DefaultSerialPort.new
+binding.pry
+
+puts 'Bye!'

--- a/console.rb
+++ b/console.rb
@@ -44,10 +44,10 @@ end
 
 EM.run do
   FB::ArduinoEventMachine.connect(bot)
-  bot.onmessage { |gcode| puts "\nINCOMING GCODE: #{gcode.name}; " }
-  bot.onchange { |diff| puts "\nSTATUS CHANGE : #{diff}; " }
+  bot.onmessage { |gcode| puts "NEW MESSAGE  : #{gcode};" }
+  bot.onchange  { |diff|  puts "STATUS CHANGE: #{diff};" }
   bot.onclose { puts "bye!"; EM.stop } # Unplug the bot and see
-  # EventMachine::PeriodicTimer.new(2) { bot.serial_port.puts "G82" }
+  # EventMachine::PeriodicTimer.new(7) { print '.'; bot.serial_port.puts "F31 P8" }
   EM.open_keyboard(KeyboardHandler, bot)
 end
 

--- a/lib/arduino.rb
+++ b/lib/arduino.rb
@@ -23,7 +23,7 @@ module FB
       @logger      = logger
       @commands    = FB::OutgoingHandler.new(self)
       @inputs      = FB::IncomingHandler.new(self)
-      @status      = FB::Status.new(self)
+      @status      = FB::Status.new
 
       start_event_listeners
     end
@@ -69,13 +69,11 @@ module FB
     def execute_command_next_tick
       EM.next_tick do
         if status.ready?
-          diff = (Time.now - (@time || Time.now)).to_i
-          log "Sending queue after #{diff}s delay" if diff > 0
+          log "Exec after #{(Time.now - (@time || Time.now)).to_i}s wait"
           serial_port.puts @outbound_queue.pop
           @time = nil
         else
           @time ||= Time.now
-          serial_port.puts "F31 P8"
           execute_command_next_tick
         end
       end

--- a/lib/arduino/event_machine.rb
+++ b/lib/arduino/event_machine.rb
@@ -15,7 +15,7 @@ module FB
     # Gets called when data arrives.
     def receive_data(data)
       split_into_chunks(data).each do |chunk|
-        if chunk.end_with?("\r\n")
+        if chunk.end_with?("\r\n") || chunk.end_with?("R00\n")
           add_to_buffer(chunk)
           send_buffer
           clear_buffer

--- a/lib/gcode.rb
+++ b/lib/gcode.rb
@@ -6,9 +6,9 @@ module FB
     attr_accessor :cmd, :params, :str
 
     def initialize(str)
-      @str = str
-      @params = str.split(' ').map{|line| GcodeToken.new(line)}
-      @cmd = @params.shift || 'NULL'
+      @str    = str
+      @params = str.split(' ').map { |line| GcodeToken.new(line) }
+      @cmd    = @params.shift || 'NULL'
     end
 
     # Turns a string of many gcodes into an array of many gcodes. Used to parse
@@ -23,6 +23,7 @@ module FB
     end
 
     def to_s
+      # self.to_s # => "A12 B23 C45"
       [@cmd, *@params].map(&:to_s).join(" ")
     end
 

--- a/lib/gcode.yml
+++ b/lib/gcode.yml
@@ -31,6 +31,11 @@
 :R2: :done
 :R3: :error
 :R4: :busy
+:R00: :idle
+:R01: :received
+:R02: :done
+:R03: :error
+:R04: :busy
 :R21: :report_parameter_value
 :R31: :report_status_value
 :R41: :report_pin_value

--- a/spec/fixtures/stub_logger.rb
+++ b/spec/fixtures/stub_logger.rb
@@ -1,0 +1,5 @@
+class StubLogger < StringIO
+  def initialize("")
+    super
+  end
+end

--- a/spec/lib/arduino/status_spec.rb
+++ b/spec/lib/arduino/status_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe FB::IncomingHandler do
+
+  let(:status) { FB::Status.new }
+
+  it "capitalizes all incoming status keys" do
+    status[:bUsY] = 345345345
+    expect(status[:BUSY]).to eq(345345345)
+    expect(status[:bUsy]).to eq(345345345)
+    expect(status[:busy]).to eq(345345345)
+  end
+
+  it "symbolizes all incoming status keys" do
+    status['busy'] = 878787
+    expect(status[:bUsy]).to eq(878787)
+  end
+
+  it "indicates BUSY status via #ready?()" do
+    status['busy'] = 1
+    expect(status.ready?).to be_falsey
+    status['busy'] = 0
+    expect(status.ready?).to be_truthy
+  end
+
+  it 'broadcasts status changes' do
+    @diff = {}
+
+    within_event_loop do
+      status.onchange { |diff| @diff = diff }
+      status[:busy] = 1
+      status[:busy] = 0
+      status[:busy] = 1
+    end
+
+    expect(status[:busy]).to eq(1)
+    expect(@diff).to eq(:BUSY => 1)
+  end
+end
+

--- a/spec/lib/gcode_spec.rb
+++ b/spec/lib/gcode_spec.rb
@@ -37,5 +37,10 @@ describe FB::Gcode do
     expect(codes.last.cmd.head).to eq(:C)
     expect(codes.first.params.first.tail).to eq(34)
   end
+
+  it 'handles parameterless Gcode' do
+    expect(FB::Gcode.new("  ").name).to be(:unknown)
+    expect(FB::Gcode.new("  ").cmd).to  eq("NULL")
+  end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,10 @@ require 'farmbot-serial'
 require_relative 'fixtures/stub_serial_port'
 RSpec.configure do |config|
 end
+
+def within_event_loop
+  EM.run do
+    yield
+    EM.next_tick { EM.stop }
+  end
+end


### PR DESCRIPTION
# What's New?

 * When collecting the serial buffer off of the input line, `R00` did not have an `\r\n` at the end, causing a backed up buffer / stalling on the raspberrypi side.
 * There was no reason to have a reference to `@bot` inside `FB::Status`, so I removed it.
 * More tests on the status object.

# What's Next?

 * Validate that it's truly the cause of the jamming.