### PR TITLE
Dynamic gcode values at time of execution

### DIFF
--- a/farmbot-serial.gemspec
+++ b/farmbot-serial.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "farmbot-serial"
-  spec.version       = '0.1.0'
+  spec.version       = '0.2.0'
   spec.authors       = ["Tim Evers", "Rick Carlino"]
   spec.email         = ["rick.carlino@gmail.com"]
   spec.description   = "Serial library for Farmbot"

--- a/lib/arduino.rb
+++ b/lib/arduino.rb
@@ -35,8 +35,8 @@ module FB
     end
 
     # Send outgoing test to arduino from pi
-    def write(string)
-      @outbound_queue.unshift string
+    def write(gcode)
+      @outbound_queue.unshift gcode
       execute_command_next_tick
     end
 

--- a/lib/arduino/outgoing_handler.rb
+++ b/lib/arduino/outgoing_handler.rb
@@ -16,11 +16,11 @@ module FB
     end
 
     def move_relative(x: 0, y: 0, z: 0, s: 100)
-      x += (bot.current_position.x || 0)
-      y += (bot.current_position.y || 0)
-      z += (bot.current_position.z || 0)
+        x += (bot.current_position.x || 0)
+        y += (bot.current_position.y || 0)
+        z += (bot.current_position.z || 0)
 
-      write "G00 X#{x} Y#{y} Z#{z}"
+        write { FB::Gcode.new { "G00 X#{x} Y#{y} Z#{z}" } }
     end
 
     def move_absolute(x: 0, y: 0, z: 0, s: 100)
@@ -61,8 +61,8 @@ module FB
 
   private
 
-    def write(str)
-      bot.write(FB::Gcode.new{ str })
+    def write(str = nil)
+      bot.write( block_given? ? obj.call : FB::Gcode.new{ str } )
     end
   end
 end

--- a/lib/arduino/outgoing_handler.rb
+++ b/lib/arduino/outgoing_handler.rb
@@ -16,11 +16,11 @@ module FB
     end
 
     def move_relative(x: 0, y: 0, z: 0, s: 100)
-        x += (bot.current_position.x || 0)
-        y += (bot.current_position.y || 0)
-        z += (bot.current_position.z || 0)
+      x += (bot.current_position.x || 0)
+      y += (bot.current_position.y || 0)
+      z += (bot.current_position.z || 0)
 
-        write { FB::Gcode.new { "G00 X#{x} Y#{y} Z#{z}" } }
+      write { FB::Gcode.new { "G00 X#{x} Y#{y} Z#{z}" } }
     end
 
     def move_absolute(x: 0, y: 0, z: 0, s: 100)
@@ -61,7 +61,7 @@ module FB
 
   private
 
-    def write(str = nil)
+    def write(str = "\n")
       bot.write( block_given? ? obj.call : FB::Gcode.new{ str } )
     end
   end

--- a/lib/arduino/outgoing_handler.rb
+++ b/lib/arduino/outgoing_handler.rb
@@ -62,7 +62,7 @@ module FB
   private
 
     def write(str)
-      bot.write(FB::Gcode.new(str))
+      bot.write(FB::Gcode.new{ str })
     end
   end
 end

--- a/lib/gcode.rb
+++ b/lib/gcode.rb
@@ -3,18 +3,16 @@ module FB
   class Gcode
     GCODE_DICTIONARY = YAML.load_file(File.join(File.dirname(__FILE__), 'gcode.yml'))
 
-    attr_accessor :cmd, :params, :str
+    attr_accessor :cmd, :params, :block
 
-    def initialize(str)
-      @str    = str
-      @params = str.split(' ').map { |line| GcodeToken.new(line) }
-      @cmd    = @params.shift || 'NULL'
+    def initialize(&block)
+      @block  = block
     end
 
     # Turns a string of many gcodes into an array of many gcodes. Used to parse
     # incoming serial.
     def self.parse_lines(string)
-      string.gsub("\r", '').split("\n").map { |s| self.new(s) }
+      string.gsub("\r", '').split("\n").map { |s| self.new { s } }
     end
 
     # Returns a symbolized english version of the gcode's name.
@@ -24,12 +22,25 @@ module FB
 
     def to_s
       # self.to_s # => "A12 B23 C45"
-      [@cmd, *@params].map(&:to_s).join(" ")
+      [cmd, *params].map(&:to_s).join(" ")
+    end
+
+    def params
+      @block
+        .call
+        .split(' ')
+        .map { |line| GcodeToken.new(line) }
+        .tap { |p| p.shift }
+    end
+
+    def cmd
+      cmd = @block.call.split(' ')
+      GcodeToken.new(cmd.any? ? cmd.first : "NULL0")
     end
 
     # A head/tail pair of a single node of GCode. Ex: R01 = [:R, '01']
     class GcodeToken
-      attr_reader :head, :tail, :name
+      attr_reader :head, :tail
 
       def initialize(str)
         nodes = str.scan(/\d+|\D+/) # ["R", "01"]

--- a/spec/lib/gcode_spec.rb
+++ b/spec/lib/gcode_spec.rb
@@ -1,17 +1,18 @@
 require 'spec_helper'
 describe FB::Gcode do
-  let(:gcode) { FB::Gcode.new("F31 P8 ")}
+  let(:gcode) { FB::Gcode.new{ "F31 P8 " } }
+  let(:null_token) { FB::Gcode::GcodeToken.new("NULL0") }
 
   it("initializes from string") { expect(gcode).to be_kind_of(FB::Gcode) }
 
   it("infers Gcode name") { expect(gcode.name).to eq(:read_status) }
 
   it "returns :unknown for bad Gcode tokens" do
-    unknown = FB::Gcode.new("QQQ31 F32 ").name
+    unknown = FB::Gcode.new{ "QQQ31 F32 " }.name
     expect(unknown).to eq(:unknown)
   end
 
-  it("sets the original input string") { expect(gcode.str).to eq("F31 P8 ") }
+  it("sets the original input string") { expect(gcode.block[]).to eq("F31 P8 ") }
 
   it("sets @cmd using the first Gcode node") do
     expect(gcode.cmd).to be_kind_of(FB::Gcode::GcodeToken)
@@ -39,8 +40,9 @@ describe FB::Gcode do
   end
 
   it 'handles parameterless Gcode' do
-    expect(FB::Gcode.new("  ").name).to be(:unknown)
-    expect(FB::Gcode.new("  ").cmd).to  eq("NULL")
+    expect(FB::Gcode.new{ "  " }.name).to be(:unknown)
+    expect(FB::Gcode.new{ "  " }.cmd.head).to eq(null_token.head)
+    expect(FB::Gcode.new{ "  " }.cmd.tail).to eq(null_token.tail)
   end
 end
 

--- a/spec/lib/gcode_spec.rb
+++ b/spec/lib/gcode_spec.rb
@@ -44,5 +44,10 @@ describe FB::Gcode do
     expect(FB::Gcode.new{ "  " }.cmd.head).to eq(null_token.head)
     expect(FB::Gcode.new{ "  " }.cmd.tail).to eq(null_token.tail)
   end
+
+  it 'sets dyanmic parameters' do
+    random_gcode = FB::Gcode.new{ "Q#{Time.now.to_f.to_s[-2, 2]}" }
+    expect(random_gcode.cmd.tail).to_not eq(random_gcode.cmd.tail)
+  end
 end
 


### PR DESCRIPTION
# Problem

 * When you write some GCode in `OutgoingHandler`, the value of the GCode is put in the queue as it is **at the current moment**
 * In the case of `move_rel`, this is very bad, because it means that the relative movement will be calculated off of the bot's coordinates when the command was sent, not off of the bot's current coordinates.

# Solution

 * Initialize GCode with a block that returns a string.
 * Don't memoize the values for safety.

# What's Next?

 * Publish changes as version `0.2`
 * Try it out on Rory's bot.