### PR TITLE
More descriptive message for GCode type mismatches

### DIFF
--- a/lib/arduino.rb
+++ b/lib/arduino.rb
@@ -79,8 +79,8 @@ module FB
         status[:last] = gcode.name
         status[:BUSY] = 1 # If not, pi will race arduino and "talk too fast"
       else
-        raise TypeError, "Outbound messages must be GCode objects. "\
-                         "Use of #{gcode.class} is not permitted."
+        raise TypeError, "Outbound messages must be GCode objects. Use of "\
+                         "#{gcode.class}:#{gcode.inspect} is not permitted."
       end
     end
 


### PR DESCRIPTION
The old message wasn't so helpful. This one calls `inspect` on the perpetrator.