### PR TITLE
Add @status.to_h() method (Version 0.6)

### DIFF
--- a/lib/arduino/status.rb
+++ b/lib/arduino/status.rb
@@ -28,6 +28,10 @@ module FB
       @info[value.upcase.to_sym]
     end
 
+    def to_h
+      @info.to_h
+    end
+
     def gcode_update(gcode)
       transaction do
         gcode.params.each do |p|

--- a/spec/lib/arduino/status_spec.rb
+++ b/spec/lib/arduino/status_spec.rb
@@ -51,5 +51,11 @@ describe FB::Status do
     expect(status.pin(2)).to eq(:unknown)
   end
 
+  it 'serializes into a hash' do
+    reality = status.instance_variable_get("@info").to_h
+    perception = status.to_h
+    expect(perception).to eq(reality)
+  end
+
 end
 


### PR DESCRIPTION
This PR adds the ability to read all status registers as a hash. This will be useful for serializing statuses into [pstore](http://ruby-doc.org/stdlib-1.9.2/libdoc/pstore/rdoc/PStore.html) / remebering where the bot was when it powered off.